### PR TITLE
easier-project-setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Thanks for contributing to **raspberry-pi-chromium-kiosk**.
 >
 > 2) Update the root `docker-compose.yml` to pull **your** image (`${REPO}:latest`).
 >
-> 3) On the Pi, pull **your fork** (or your branch), run the setup with your image (should work just by updating docker compose)
+> 3. On the Pi, pull **your fork** (or your branch), and run the manual setup (not the one command one) with your image (this should work just by updating `docker-compose.yml`).
 
 ### PR expectations
 

--- a/README.md
+++ b/README.md
@@ -34,30 +34,30 @@ A Raspberry Pi kiosk setup that boots straight into **Chromium in kiosk mode**, 
 > https://daniel-gia.github.io/raspberry-pi-chromium-kiosk/getting-started/
 
 1. Install **Raspberry Pi OS Lite** (using the official Raspberry Pi imaging tool)
-2. Install git:
-   ```sh
-   sudo apt install git
-   ```
-3. Clone the repository:
-   ```sh
-   sudo git clone https://github.com/Daniel-Gia/raspberry-pi-chromium-kiosk.git
-   ```
-4. Go to the setup folder:
-   ```sh
-   cd raspberry-pi-chromium-kiosk/setup
-   ```
-5. Make the setup script executable:
-   ```sh
-   sudo chmod +x setup.sh
-   ```
-6. Run the setup:
-   ```sh
-   sudo ./setup.sh
-   ```
-7. Generate admin panel login credentials:
-   ```sh
-   sudo ./generate-admin-login.sh {username} {password}
-   ```
+
+### Quick Install (Recommended)
+
+Run this single command on your Raspberry Pi to install everything:
+
+```sh
+curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>
+```
+
+*Replace `<username>` and `<password>` with your desired admin panel credentials.*
+
+This script will:
+1. Install dependencies (Docker, Kiosk service, etc.)
+2. Configure the system
+3. Set your admin credentials
+
+Once finished, **reboot** your Pi:
+```sh
+sudo reboot
+```
+
+### Manual Install
+
+If you prefer to clone the repo and run scripts manually, please see the [Manual Setup Guide](https://daniel-gia.github.io/raspberry-pi-chromium-kiosk/getting-started/).
 8. Reboot:
    ```sh
    sudo reboot

--- a/docs/contribute/create-a-pr.md
+++ b/docs/contribute/create-a-pr.md
@@ -37,7 +37,7 @@
 
     2. Update the root `docker-compose.yml` to pull **your** image (`${REPO}:latest`).
 
-    3. On the Pi, pull **your fork** (or your branch), and run the setup with your image (this should work just by updating `docker-compose.yml`).
+    3. On the Pi, pull **your fork** (or your branch), and run the [manual setup](/getting-started/) with your image (this should work just by updating `docker-compose.yml`).
 
 ### PR expectations
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,37 +10,54 @@
 !!! note "Terminal access"
     You’ll need terminal access to the Pi for the steps below — either connect a keyboard for a local terminal, or SSH into the Pi from another machine.
 
-1. Install Git:
+=== "Automatic (Recommended)"
+
+    Run the following command to download and install everything automatically:
+
     ```sh
-    sudo apt update
-    sudo apt install git
+    curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>
     ```
 
-2. Clone the repository:
-   ```sh
-   sudo git clone https://github.com/Daniel-Gia/raspberry-pi-chromium-kiosk.git
-   ```
+    *Replace `<username>` and `<password>` with the credentials you want to use for the Admin Panel.*
 
-3. Run the setup script:
-   ```sh
-   cd raspberry-pi-chromium-kiosk/setup
-   sudo chmod +x setup.sh
-   sudo ./setup.sh
-   ```
+    Once the script finishes, reboot.
+    ```sh
+    sudo reboot
+    ```
 
-4. Generate admin panel login credentials:
-   ```sh
-   sudo ./generate-admin-login.sh {username} {password}
-   ```
+=== "Manual"
 
-5. Reboot:
-   ```sh
-   sudo reboot
-   ```
+    1. Install Git:
+        ```sh
+        sudo apt update
+        sudo apt install git
+        ```
+
+    2. Clone the repository:
+       ```sh
+       sudo git clone https://github.com/Daniel-Gia/raspberry-pi-chromium-kiosk.git
+       ```
+
+    3. Run the setup script:
+       ```sh
+       cd raspberry-pi-chromium-kiosk/setup
+       sudo chmod +x setup.sh
+       sudo ./setup.sh
+       ```
+
+    4. Generate admin panel login credentials:
+       ```sh
+       sudo ./generate-admin-login.sh {username} {password}
+       ```
+
+    5. Reboot:
+       ```sh
+       sudo reboot
+       ```
 
 ## After reboot
 - The **kiosk browser** should start automatically.
-- The **admin panel** runs via Docker Compose (using host networking).
+- The **admin panel** runs via Docker Compose.
 
 ## Open the admin panel
 From any device on the same network, open:

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# Usage: curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/bootstrap.sh | sudo bash -s -- {username} {password}
+
+set -euo pipefail
+
+REPO_OWNER="Daniel-Gia"
+REPO_NAME="raspberry-pi-chromium-kiosk"
+
+# Determine install directory
+if [ -n "${SUDO_USER:-}" ]; then
+    USER_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+    INSTALL_DIR="$USER_HOME/$REPO_NAME"
+else
+    INSTALL_DIR="/opt/$REPO_NAME"
+fi
+
+echo "Installing to: $INSTALL_DIR"
+
+USERNAME="${1:-}"
+PASSWORD="${2:-}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as root. Please use sudo."
+    exit 1
+fi
+
+echo "== Raspberry Pi Chromium Kiosk =="
+
+echo "Installing dependencies..."
+apt-get update
+apt-get install -y curl tar
+
+# Get the latest release
+echo "Fetching latest release info..."
+LATEST_RELEASE_DATA=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest")
+DOWNLOAD_URL=$(echo "$LATEST_RELEASE_DATA" | grep '"tarball_url":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$DOWNLOAD_URL" ]; then
+    echo "Warning: Could not find the latest release. Downloading the 'main' branch."
+    DOWNLOAD_URL="https://github.com/$REPO_OWNER/$REPO_NAME/archive/refs/heads/main.tar.gz"
+fi
+
+echo "Downloading from: $DOWNLOAD_URL"
+
+if [ -d "$INSTALL_DIR" ]; then
+    echo "Removing existing installation in $INSTALL_DIR..."
+    rm -rf "$INSTALL_DIR"
+fi
+mkdir -p "$INSTALL_DIR"
+
+echo "Downloading and extracting..."
+curl -L "$DOWNLOAD_URL" | tar -xz -C "$INSTALL_DIR" --strip-components=1
+
+echo "Running setup script..."
+cd "$INSTALL_DIR"
+chmod +x setup/setup.sh
+./setup/setup.sh
+
+echo "Generating admin login..."
+if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
+    echo "No username/password provided. Using defaults."
+    USERNAME="admin"
+    PASSWORD="admin"
+    echo "Default credentials -> Username: $USERNAME, Password: $PASSWORD"
+else
+    echo "Using provided credentials for admin panel."
+fi
+
+chmod +x setup/generate-admin-login.sh
+./setup/generate-admin-login.sh "$USERNAME" "$PASSWORD"
+
+echo ""
+echo "Install completed."
+echo "The project is installed in: $INSTALL_DIR"
+echo "Admin panel credentials configured."
+echo "run \"sudo reboot now\" to start the kiosk browser."


### PR DESCRIPTION
### Description

Added an easier setup option so people can just do
curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>

### Checklist
- [x] I have performed a self-review of my own code.
- [x] I have tested the code / changes on a  Raspberry Pi device.
- [x] I added a documentation for the changes I have made (when necessary).