### PR TITLE
Added dev setup for easier testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,17 +58,7 @@ Thanks for contributing to **raspberry-pi-chromium-kiosk**.
 
 > Tip
 >
-> If you change anything in the **admin panel**, the easiest way to test it on a Raspberry Pi is to build and push your own ARM64 image (e.g. to docker hub), then point the Pi to that image.
->
-> 1) Build + push an ARM64 image (run from the `admin-panel/` directory):
->
-> ```sh
-> docker buildx build --platform linux/arm64 -t ${REPO}:latest -f Dockerfile . --push
-> ```
->
-> 2) Update the root `docker-compose.yml` to pull **your** image (`${REPO}:latest`).
->
-> 3. On the Pi, pull **your fork** (or your branch), and run the manual setup (not the one command one) with your image (this should work just by updating `docker-compose.yml`).
+> If you change anything in the **admin panel**, the easiest way to test it is to follow this steps [test changes locally](https://daniel-gia.github.io/raspberry-pi-chromium-kiosk/contribute/test-locally)
 
 ### PR expectations
 

--- a/admin-panel/app/api/auth/[...nextauth]/route.ts
+++ b/admin-panel/app/api/auth/[...nextauth]/route.ts
@@ -11,10 +11,15 @@ type AuthInfo = {
 
 const readAuthEnv = (): AuthInfo | null => {
     const username = process.env.ADMIN_PANEL_USERNAME;
-    const passwordHash = process.env.ADMIN_PANEL_PASSWORD_HASH;
+    let passwordHash = process.env.ADMIN_PANEL_PASSWORD_HASH;
 
     if (typeof username !== "string" || username.trim() === "") return null;
     if (typeof passwordHash !== "string" || passwordHash.trim() === "") return null;
+
+    // When running locally using npm, we might get the double escaped string from .env so we fix it here
+    if (passwordHash.startsWith("$$")) {
+        passwordHash = passwordHash.replace(/\$\$/g, "$");
+    }
 
     return {
         username: username.trim(),

--- a/docs/contribute/create-a-pr.md
+++ b/docs/contribute/create-a-pr.md
@@ -27,17 +27,7 @@
 
 !!! tip "Test admin-panel changes on your Raspberry Pi"
 
-    If you change anything in the **admin panel**, the easiest way to test it on a Raspberry Pi is to build and push your own ARM64 image (e.g. to Docker Hub), then point the Pi to that image.
-
-    1. Build + push an ARM64 image (run from the `admin-panel/` directory):
-
-        ```sh
-        docker buildx build --platform linux/arm64 -t ${REPO}:latest -f Dockerfile . --push
-        ```
-
-    2. Update the root `docker-compose.yml` to pull **your** image (`${REPO}:latest`).
-
-    3. On the Pi, pull **your fork** (or your branch), and run the [manual setup](/getting-started/) with your image (this should work just by updating `docker-compose.yml`).
+    If you change anything in the **admin panel**, the easiest way to test it is to follow this steps [test changes locally](/contribute/test-locally)
 
 ### PR expectations
 

--- a/docs/contribute/test-locally.md
+++ b/docs/contribute/test-locally.md
@@ -1,0 +1,65 @@
+# Test Locally
+
+To test your changes on a Raspberry Pi without building Docker images, you can use the development setup mode. This runs the Admin Panel directly on the host using `npm run dev`, allowing for faster testing.
+
+## Prerequisites
+
+- A Raspberry Pi with Raspberry Pi OS installed.
+- SSH access to the Pi.
+- Your fork of the repository with your changes pushed to a branch.
+
+## Steps
+
+1.  **Clone your fork and checkout your branch:**
+
+    SSH into your Raspberry Pi and run:
+
+    ```sh
+    # Replace with your fork URL and branch name
+    git clone https://github.com/YOUR_USERNAME/raspberry-pi-chromium-kiosk.git
+    cd raspberry-pi-chromium-kiosk
+    git checkout your-feature-branch
+    ```
+
+2.  **Run the setup in Development Mode:**
+
+    Navigate to the setup directory and run the script with the `--dev` flag:
+
+    ```sh
+    cd setup
+    sudo chmod +x setup.sh
+    sudo ./setup.sh --dev
+    ```
+
+    This will:
+    
+    - Install Node.js (v20) if missing.
+    - Install `npm` dependencies for the Admin Panel.
+    - Configure the `admin-panel-dev` systemd service to run via `npm run dev` (instead of Docker).
+    - Disable the production Docker service.
+
+3.  **Generate Admin Credentials:**
+
+    If you haven't already, generate the login credentials for the Admin Panel:
+
+    ```sh
+    # Usage: sudo ./generate-admin-login.sh <username> <password>
+    sudo ./generate-admin-login.sh admin mypassword
+    ```
+
+4.  **Reboot:**
+
+    Reboot the Pi to start the Kiosk Browser and the Admin Panel service:
+
+    ```sh
+    sudo reboot
+    ```
+
+## Verification
+
+After rebooting, the Kiosk Browser should launch. You can access the Admin Panel from another computer on the same network:
+
+- URL: `http://<RASPBERRY_PI_IP>`
+- Login: The credentials you generated in step 3.
+
+Since the Admin Panel is running with `npm run dev`, any changes you make to the files in `~/raspberry-pi-chromium-kiosk/admin-panel` on the Pi will be reflected immediately (or after a page refresh).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Contribute:
       - First steps: contribute/first-steps.md
       - Understand project structure: contribute/understand-project-structure.md
+      - Test Changes Locally: contribute/test-locally.md
       - Create an issue: contribute/create-an-issue.md
       - Create a PR: contribute/create-a-pr.md
       - Update docs: contribute/update-docs.md

--- a/setup/admin-panel-dev.service
+++ b/setup/admin-panel-dev.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Admin Panel Dev Service (npm)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=@REPO_DIR@/admin-panel
+Environment=PORT=80
+EnvironmentFile=@REPO_DIR@/.env
+# Run Next.js in dev mode on port 80, accessible from network
+ExecStart=/usr/bin/npm run dev -- -p 80 -H 0.0.0.0
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 # chmod +x setup.sh
+# Usage: ./setup.sh [--dev]
 
 set -euo pipefail
 
 SETUP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SETUP_DIR/.." && pwd)"
+
+DEV_MODE=false
+if [ "${1:-}" == "--dev" ]; then
+    DEV_MODE=true
+    echo ">> DEV MODE ENABLED: Will setup admin-panel using npm (host) instead of Docker."
+fi
 
 echo "== Raspberry Pi Chromium Kiosk Project Setup =="
 
@@ -12,18 +19,29 @@ echo "1) Installing required packages (openssl, htpasswd)..."
 sudo apt-get update
 sudo apt-get install -y openssl apache2-utils
 
-if ! command -v docker &> /dev/null; then
-    echo "2) Installing Docker..."
-    curl -sSL https://get.docker.com | sh
+if [ "$DEV_MODE" = true ]; then
+    echo "2) Installing Node.js 20 (Dev Mode)..."
+    if ! command -v node &> /dev/null; then
+        # Install Node.js 20.x
+        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+        sudo apt-get install -y nodejs
+    else
+        echo "Node.js is already installed."
+    fi
 else
-    echo "2) Docker is already installed. Skipping installation."
+    if ! command -v docker &> /dev/null; then
+        echo "2) Installing Docker..."
+        curl -sSL https://get.docker.com | sh
+    else
+        echo "2) Docker is already installed. Skipping installation."
+    fi
+
+    echo "3) Enabling Docker..."
+    sudo systemctl enable --now docker
+
+    echo "4) Pulling latest Docker images..."
+    docker compose -f "$REPO_DIR/docker-compose.yml" pull
 fi
-
-echo "3) Enabling Docker..."
-sudo systemctl enable --now docker
-
-echo "4) Pulling latest Docker images..."
-docker compose -f "$REPO_DIR/docker-compose.yml" pull
 
 echo "5) Running kiosk-browser setup..."
 chmod +x "$REPO_DIR/kiosk-browser/setup.sh"
@@ -32,19 +50,46 @@ chmod +x "$REPO_DIR/kiosk-browser/setup.sh"
 echo "6) Making generate-admin-login.sh executable..."
 chmod +x "$REPO_DIR/setup/generate-admin-login.sh"
 
-echo "7) Installing admin-panel docker compose systemd service..."
-SERVICE_PATH="/etc/systemd/system/admin-panel.service"
-TEMPLATE_PATH="$REPO_DIR/setup/admin-panel.service"
+if [ "$DEV_MODE" = true ]; then
+    echo "7) Installing admin-panel dev service (npm)..."
+    
+    echo "   Installing npm dependencies in admin-panel/..."
+    cd "$REPO_DIR/admin-panel"
+    npm install
 
-if [ ! -f "$TEMPLATE_PATH" ]; then
-  echo "Missing template: $TEMPLATE_PATH"
-  exit 1
+    SERVICE_PATH="/etc/systemd/system/admin-panel-dev.service"
+    TEMPLATE_PATH="$REPO_DIR/setup/admin-panel-dev.service"
+
+    if [ ! -f "$TEMPLATE_PATH" ]; then
+      echo "Missing template: $TEMPLATE_PATH"
+      exit 1
+    fi
+
+    # Disable production service if it exists to avoid port conflicts
+    sudo systemctl disable --now admin-panel.service 2>/dev/null || true
+
+    sudo sed -e "s|@REPO_DIR@|$REPO_DIR|g" "$TEMPLATE_PATH" | sudo tee "$SERVICE_PATH" > /dev/null
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable admin-panel-dev.service
+else
+    echo "7) Installing admin-panel docker compose systemd service..."
+    SERVICE_PATH="/etc/systemd/system/admin-panel.service"
+    TEMPLATE_PATH="$REPO_DIR/setup/admin-panel.service"
+
+    if [ ! -f "$TEMPLATE_PATH" ]; then
+      echo "Missing template: $TEMPLATE_PATH"
+      exit 1
+    fi
+
+    # Disable dev service if it exists
+    sudo systemctl disable --now admin-panel-dev.service 2>/dev/null || true
+
+    sudo sed -e "s|@REPO_DIR@|$REPO_DIR|g" "$TEMPLATE_PATH" | sudo tee "$SERVICE_PATH" > /dev/null
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable admin-panel.service
 fi
-
-sudo sed -e "s|@REPO_DIR@|$REPO_DIR|g" "$TEMPLATE_PATH" | sudo tee "$SERVICE_PATH" > /dev/null
-
-sudo systemctl daemon-reload
-sudo systemctl enable admin-panel.service
 
 echo "-------------------------------------------------------"
 echo "Done! Now please run the generate-admin-login.sh script to create admin login credentials."


### PR DESCRIPTION
### Description

1. Added dev setup for easier testing.
- to use it in sude setup add the --dev flag, so: 
    ```sh
      sudo ./setup.sh --dev
    ```
- this will use npm run dev for admin panel instead of docker image

2. Added test-locally page to docs

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested the code / changes on a  Raspberry Pi device.
- [x] I added a documentation for the changes I have made (when necessary).