### PR TITLE
Use the right release for docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,7 @@ A Raspberry Pi kiosk setup that boots straight into **Chromium in kiosk mode**, 
 
 1. Install **Raspberry Pi OS Lite** (using the official Raspberry Pi imaging tool)
 
-### Quick Install (Recommended)
-
-Run this single command on your Raspberry Pi to install everything:
+2. Run this single command on your Raspberry Pi to install everything:
 
 ```sh
 curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>
@@ -45,14 +43,10 @@ curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kio
 
 *Replace `<username>` and `<password>` with your desired admin panel credentials.*
 
-Once finished, **reboot** your Pi:
+3. Once finished, **reboot** your Pi:
 ```sh
 sudo reboot
 ```
-
-### Manual Install
-
-If you prefer to clone the repo and run scripts manually, please see the [Manual Setup Guide](https://daniel-gia.github.io/raspberry-pi-chromium-kiosk/getting-started/).
 
 After reboot:
 - The **kiosk browser** should start automatically on the Pi.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   admin-panel:
-    image: ghcr.io/daniel-gia/raspberry-pi-chromium-kiosk-admin-panel:latest
+    image: ghcr.io/daniel-gia/raspberry-pi-chromium-kiosk-admin-panel:${IMAGE_TAG:-latest}
     pull_policy: always
     restart: unless-stopped
     network_mode: host

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,50 +10,19 @@
 !!! note "Terminal access"
     You’ll need terminal access to the Pi for the steps below — either connect a keyboard for a local terminal, or SSH into the Pi from another machine.
 
-=== "Automatic (Recommended)"
 
-    Run the following command to download and install everything automatically:
+Run the following command to download and install everything automatically:
 
-    ```sh
-    curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>
-    ```
+```sh
+curl -sSL https://raw.githubusercontent.com/Daniel-Gia/raspberry-pi-chromium-kiosk/main/setup/install.sh | sudo bash -s -- <username> <password>
+```
 
-    *Replace `<username>` and `<password>` with the credentials you want to use for the Admin Panel.*
+*Replace `<username>` and `<password>` with the credentials you want to use for the Admin Panel.*
 
-    Once the script finishes, reboot.
-    ```sh
-    sudo reboot
-    ```
-
-=== "Manual"
-
-    1. Install Git:
-        ```sh
-        sudo apt update
-        sudo apt install git
-        ```
-
-    2. Clone the repository:
-       ```sh
-       sudo git clone https://github.com/Daniel-Gia/raspberry-pi-chromium-kiosk.git
-       ```
-
-    3. Run the setup script:
-       ```sh
-       cd raspberry-pi-chromium-kiosk/setup
-       sudo chmod +x setup.sh
-       sudo ./setup.sh
-       ```
-
-    4. Generate admin panel login credentials:
-       ```sh
-       sudo ./generate-admin-login.sh {username} {password}
-       ```
-
-    5. Reboot:
-       ```sh
-       sudo reboot
-       ```
+Once the script finishes, reboot.
+```sh
+sudo reboot
+```
 
 ## After reboot
 - The **kiosk browser** should start automatically.

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -35,10 +35,12 @@ apt-get install -y curl tar
 echo "Fetching latest release info..."
 LATEST_RELEASE_DATA=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest")
 DOWNLOAD_URL=$(echo "$LATEST_RELEASE_DATA" | grep '"tarball_url":' | sed -E 's/.*"([^"]+)".*/\1/')
+RELEASE_TAG=$(echo "$LATEST_RELEASE_DATA" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
 if [ -z "$DOWNLOAD_URL" ]; then
     echo "Warning: Could not find the latest release. Downloading the 'main' branch."
     DOWNLOAD_URL="https://github.com/$REPO_OWNER/$REPO_NAME/archive/refs/heads/main.tar.gz"
+    RELEASE_TAG="latest"
 fi
 
 echo "Downloading from: $DOWNLOAD_URL"
@@ -51,6 +53,15 @@ mkdir -p "$INSTALL_DIR"
 
 echo "Downloading and extracting..."
 curl -L "$DOWNLOAD_URL" | tar -xz -C "$INSTALL_DIR" --strip-components=1
+
+echo "Configuring Docker image version in env..."
+if [ -n "$RELEASE_TAG" ] && [ "$RELEASE_TAG" != "null" ]; then
+    echo "IMAGE_TAG=$RELEASE_TAG" > "$INSTALL_DIR/.env"
+    echo "Pinned Docker image to: $RELEASE_TAG"
+else
+    echo "IMAGE_TAG=latest" > "$INSTALL_DIR/.env"
+    echo "Pinned Docker image to: latest"
+fi
 
 echo "Running setup script..."
 cd "$INSTALL_DIR"
@@ -74,4 +85,4 @@ echo ""
 echo "Install completed."
 echo "The project is installed in: $INSTALL_DIR"
 echo "Admin panel credentials configured."
-echo "run \"sudo reboot now\" to start the kiosk browser."
+echo "run \"sudo reboot\" to start the kiosk browser."


### PR DESCRIPTION
### Description

1.
Previously it could happen docker would pull the latest image that wouldn't be compatible with the the current version of the code we have
so we prevent this (an env with info what docker image version to use)

2. Removed the manual option to setup the project, because that option would still always use the latest docker image

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested the code / changes on a  Raspberry Pi device.
- [x] I added a documentation for the changes I have made (when necessary).