### PR TITLE
Wait for localhost before starting chromium

### DIFF
--- a/kiosk-browser/start_browser.sh
+++ b/kiosk-browser/start_browser.sh
@@ -14,6 +14,15 @@ if [ -z "$START_URL" ]; then
   START_URL="http://localhost/show-ip"
 fi
 
+# If START_URL is localhost, wait for it to be accessible (any response is fine)
+if [[ "$START_URL" == http://localhost* ]]; then
+  echo "Waiting for localhost to respond..."
+  until curl -s --head --request GET http://localhost > /dev/null; do
+    sleep 1
+  done
+  echo "Localhost is responding."
+fi
+
 CHROMIUM_CMD="chromium \
   --ozone-platform=wayland \
   --enable-features=UseOzonePlatform \


### PR DESCRIPTION
### Description

Wait for localhost before starting chromium

so we dont see an error on chrome

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested the code / changes on a  Raspberry Pi device.
- [ ] I added a documentation for the changes I have made (when necessary).