### PR TITLE
Add workflow to build/push admin-panel image

### DIFF
--- a/.github/workflows/build-and-push-admin-panel.yml
+++ b/.github/workflows/build-and-push-admin-panel.yml
@@ -1,0 +1,40 @@
+name: Build and Push Admin Panel Docker Image
+
+on:
+  release:
+    types:
+      - created
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: admin-panel
+          file: admin-panel/Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/daniel-gia/raspberry-pi-chromium-kiosk-admin-panel:latest
+            ghcr.io/daniel-gia/raspberry-pi-chromium-kiosk-admin-panel:${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Description

Adds a GitHub Actions workflow triggered on release creation to build and push the admin-panel Docker image

### Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have tested the code / changes on a  Raspberry Pi device.
- [ ] I added a documentation for the changes I have made (when necessary).